### PR TITLE
Potential fix for network variable issues?

### DIFF
--- a/src/main/java/me/limeglass/skungee/bungeecord/handlers/NetworkVariableHandler.java
+++ b/src/main/java/me/limeglass/skungee/bungeecord/handlers/NetworkVariableHandler.java
@@ -4,6 +4,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import com.google.common.collect.Lists;
 
+import me.limeglass.skungee.bungeecord.Skungee;
 import me.limeglass.skungee.bungeecord.handlercontroller.SkungeeBungeeHandler;
 import me.limeglass.skungee.bungeecord.variables.VariableManager;
 import me.limeglass.skungee.objects.SkungeeEnums.SkriptChangeMode;

--- a/src/main/java/me/limeglass/skungee/bungeecord/handlers/NetworkVariableHandler.java
+++ b/src/main/java/me/limeglass/skungee/bungeecord/handlers/NetworkVariableHandler.java
@@ -4,7 +4,6 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import com.google.common.collect.Lists;
 
-import me.limeglass.skungee.bungeecord.Skungee;
 import me.limeglass.skungee.bungeecord.handlercontroller.SkungeeBungeeHandler;
 import me.limeglass.skungee.bungeecord.variables.VariableManager;
 import me.limeglass.skungee.objects.SkungeeEnums.SkriptChangeMode;

--- a/src/main/java/me/limeglass/skungee/spigot/elements/expressions/ExprNetworkVariable.java
+++ b/src/main/java/me/limeglass/skungee/spigot/elements/expressions/ExprNetworkVariable.java
@@ -123,7 +123,7 @@ public class ExprNetworkVariable extends SkungeeExpression<Object> {
 			}
 		}
 		SkungeeVariable variable = new SkungeeVariable(variableString.toString(event), values);
-		sockets.send(new SkungeePacket(true, SkungeePacketType.NETWORKVARIABLE, variable, changer));
+		sockets.send(new SkungeePacket(false, SkungeePacketType.NETWORKVARIABLE, variable, changer));
 	}
 
 }


### PR DESCRIPTION
Up until my fix, trying to set a network variable would fail and would return ```<none>```, and also break many of the syntax I was using in my scripts simultaneously. 
I looked through the codebase and noticed that changing a network variable would result in no actual response sent back (which would make sense, as you aren't requesting anything). Changing ```true``` to ```false``` for returnable would correct this.

After this small change, network variables have seemed to work perfectly fine for me.